### PR TITLE
"a inspector" to "an inspector", 3 instances

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,7 +568,7 @@ dl.dl-horizontal > dd {
         <h2>Verify claim</h2>
         <dl class="dl-horizontal">
             <dt>Requirement</dt>
-            <dd>It MUST be possible for a <a>inspector</a> to verify that the
+            <dd>It MUST be possible for an <a>inspector</a> to verify that the
             credential is an authentic statement of an <a>issuer's</a> claims
             about the <a>subject</a>. The verifying entity must have the
             capability to connect the issuer’s identity to its
@@ -614,10 +614,10 @@ dl.dl-horizontal > dd {
             <dt>Requirement</dt>
             <dd>It MUST be possible for a <a>holder</a> to select if and which
             appropriate
-            credential should be sent to a <a>inspector</a>.</dd>
+            credential should be sent to an <a>inspector</a>.</dd>
             <dt>Motivations</dt>
             <dd>
-            A <a>inspector</a> may require that a <a>holder</a> verify aspects
+            An <a>inspector</a> may require that a <a>holder</a> verify aspects
             of their suitability for a transaction.  In this case, the
             <a>holder</a> must be able to select which, if any, 
             <a>Verifiable Claim</a> stored with their <a>Credential Repository</a> 


### PR DESCRIPTION
Sec 4.3 and 4.5 “a inspector” should be “an inspector”; changed 3 instances.
Fixes #11.

This is my first ever commit! So it's a little one. Ta Da!